### PR TITLE
Add `simulator` function to `SBC`

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - python >= 3.11
   - pymc>=5.20.1
-  - bambi>=0.13.0
+  - bambi>=0.14.0
   - arviz>=0.20.0
   - black=22.3.0
   - click=8.0.4
@@ -15,4 +15,3 @@ dependencies:
   - pytest>=4.4.0
   - pre-commit>=2.19
   - ruff==0.9.1
-

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - python >= 3.11
   - pymc>=5.20.1
-  - bambi>=0.14.0
+  - bambi>=0.13.0
   - arviz>=0.20.0
   - black=22.3.0
   - click=8.0.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest>=4.4.0
 pre-commit>=2.19
 ipytest==0.13.0
 pymc>=5.20.1
-bambi>=0.14.0
+bambi>=0.13.0
 arviz_base>=0.5.0
 ruff==0.9.1
 numpyro>=0.17.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ bambi>=0.13.0
 arviz_base>=0.5.0
 ruff==0.9.1
 numpyro>=0.17.0
+numba>=0.60.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest>=4.4.0
 pre-commit>=2.19
 ipytest==0.13.0
 pymc>=5.20.1
-bambi>=0.13.0
+bambi>=0.14.0
 arviz_base>=0.5.0
 ruff==0.9.1
 numpyro>=0.17.0

--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -18,9 +18,8 @@ except ImportError:
 
 import numpy as np
 import xarray as xr
-from arviz_base import extract, from_dict, from_numpyro
+from arviz_base import extract, from_dict, dict_to_dataset, from_numpyro
 from tqdm import tqdm
-
 
 class quiet_logging:
     """Turn off logging for PyMC, Bambi and PyTensor."""

--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -63,7 +63,7 @@ class SBC:
         an MCMC Kernel model.
         simulator : callable
             A custom simulator function that takes as input the model parameters and
-            a int parameter named `seed`, and returns a dictionary of named observations.
+            a int parameter named `seed`, and must return a dictionary of named observations.
 
     Example
     -------

--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -16,10 +16,12 @@ try:
 except ImportError:
     pass
 
+from collections.abc import Mapping
+
 import numpy as np
-import xarray as xr
-from arviz_base import extract, from_dict, dict_to_dataset, from_numpyro
+from arviz_base import dict_to_dataset, extract, from_dict, from_numpyro
 from tqdm import tqdm
+
 
 class quiet_logging:
     """Turn off logging for PyMC, Bambi and PyTensor."""
@@ -181,17 +183,18 @@ class SBC:
                 try:
                     res = self.simulator(**params)
                     assert isinstance(
-                        res, dict
+                        res, Mapping
                     ), f"Simulator must return a dictionary, got {type(res)}"
                     prior_pred.append(res)
                 except Exception as e:
                     raise ValueError(
                         f"Error generating prior predictive sample with parameters {params}: {e}."
                     )
-            prior_pred = dict_to_dataset({key: np.stack([pp[key] for pp in prior_pred]) for key in prior_pred[0]},
-                    sample_dims=["sample"],
-                    coords={**prior.coords},
-                    )
+            prior_pred = dict_to_dataset(
+                {key: np.stack([pp[key] for pp in prior_pred]) for key in prior_pred[0]},
+                sample_dims=["sample"],
+                coords={**prior.coords},
+            )
         return prior, prior_pred
 
     def _get_prior_predictive_samples_numpyro(self):

--- a/simuk/tests/test_sbc.py
+++ b/simuk/tests/test_sbc.py
@@ -1,4 +1,5 @@
 import bambi as bmb
+import jax.numpy as jnp
 import numpy as np
 import numpyro
 import numpyro.distributions as dist
@@ -11,23 +12,64 @@ import simuk
 
 np.random.seed(1234)
 
+# Test data
 data = np.array([28.0, 8.0, -3.0, 7.0, -1.0, 1.0, 18.0, 12.0])
 sigma = np.array([15.0, 10.0, 16.0, 11.0, 9.0, 11.0, 10.0, 18.0])
 
+# PyMC models
 with pm.Model() as centered_eight:
     mu = pm.Normal("mu", mu=0, sigma=5)
     tau = pm.HalfCauchy("tau", beta=5)
     theta = pm.Normal("theta", mu=mu, sigma=tau, shape=8)
     y_obs = pm.Normal("y", mu=theta, sigma=sigma, observed=data)
 
+with pm.Model() as centered_eight_no_observed:
+    mu = pm.Normal("mu", mu=0, sigma=5)
+    tau = pm.HalfCauchy("tau", beta=5)
+    theta = pm.Normal("theta", mu=mu, sigma=tau, shape=8)
+
+    def log_likelihood(theta, observed):
+        return pm.math.sum(pm.logp(pm.Normal.dist(mu=theta, sigma=sigma), observed))
+
+    pm.Potential("y_loglike", log_likelihood(mu, data))
+
+# Bambi model
 x = np.random.normal(0, 1, 20)
 y = 2 + np.random.normal(x, 1)
 df = pd.DataFrame({"x": x, "y": y})
 bmb_model = bmb.Model("y ~ x", df)
 
+# NumPyro models
+def eight_schools_cauchy_prior(J, sigma, y=None):
+    mu = numpyro.sample("mu", dist.Normal(0, 5))
+    tau = numpyro.sample("tau", dist.HalfCauchy(5))
+    with numpyro.plate("J", J):
+        theta = numpyro.sample("theta", dist.Normal(mu, tau))
+    numpyro.sample("y", dist.Normal(theta, sigma), obs=y)
 
+
+def eight_schools_cauchy_prior_no_observed(J, sigma, y=None):
+    mu = numpyro.sample("mu", dist.Normal(0, 5))
+    tau = numpyro.sample("tau", dist.HalfCauchy(5))
+    with numpyro.plate("J", J):
+        theta = numpyro.sample("theta", dist.Normal(mu, tau))
+    if y is not None:
+        log_likelihood = jnp.sum(dist.Normal(theta, sigma).log_prob(y))
+        numpyro.factor("custom_likelihood", log_likelihood)
+
+
+# Custom simulator functions
+def centered_eight_simulator(theta, **kwargs):
+    return {"y": np.random.normal(theta, sigma)}
+
+
+def bmb_simulator(mu, sigma, **kwargs):
+    return {"y": np.random.normal(mu, sigma)}
+
+
+# --- Tests with observed variables ---
 @pytest.mark.parametrize("model", [centered_eight, bmb_model])
-def test_sbc(model):
+def test_sbc_with_observed_data(model):
     sbc = simuk.SBC(
         model,
         num_simulations=10,
@@ -37,22 +79,76 @@ def test_sbc(model):
     assert "prior_sbc" in sbc.simulations
 
 
-def test_sbc_numpyro():
-    y = np.array([28.0, 8.0, -3.0, 7.0, -1.0, 1.0, 18.0, 12.0])
-    sigma = np.array([15.0, 10.0, 16.0, 11.0, 9.0, 11.0, 10.0, 18.0])
-
-    def eight_schools_cauchy_prior(J, sigma, y=None):
-        mu = numpyro.sample("mu", dist.Normal(0, 5))
-        tau = numpyro.sample("tau", dist.HalfCauchy(5))
-        with numpyro.plate("J", J):
-            theta = numpyro.sample("theta", dist.Normal(mu, tau))
-        numpyro.sample("y", dist.Normal(theta, sigma), obs=y)
-
+def test_sbc_numpyro_with_observed_data():
     sbc = simuk.SBC(
         NUTS(eight_schools_cauchy_prior),
-        data_dir={"J": 8, "sigma": sigma, "y": y},
+        data_dir={"J": 8, "sigma": sigma, "y": data},
         num_simulations=10,
         sample_kwargs={"num_warmup": 50, "num_samples": 25},
     )
     sbc.run_simulations()
     assert "prior_sbc" in sbc.simulations
+
+
+# --- Tests with custom simulators ---
+@pytest.mark.parametrize(
+    "model,simulator",
+    [
+        # Case 1: Both simulator function and observed variables present
+        (centered_eight, centered_eight_simulator),
+        # Case 2: Only simulator function present
+        (centered_eight_no_observed, centered_eight_simulator),
+        # Case 3: bambi model with custom simulator
+        (bmb_model, bmb_simulator),
+    ],
+)
+def test_sbc_with_custom_simulator(model, simulator):
+    sbc = simuk.SBC(
+        model, num_simulations=10, sample_kwargs={"draws": 5, "tune": 5}, simulator=simulator
+    )
+    sbc.run_simulations()
+    assert "prior_sbc" in sbc.simulations
+
+
+@pytest.mark.parametrize(
+    "model,simulator",
+    [
+        # Case 1: Both simulator function and observed variables present
+        (eight_schools_cauchy_prior, centered_eight_simulator),
+        # Case 2: Only simulator function present
+        (eight_schools_cauchy_prior_no_observed, centered_eight_simulator),
+    ],
+)
+def test_sbc_numpyro_with_custom_simulator(model, simulator):
+    sbc = simuk.SBC(
+        NUTS(model),
+        data_dir={"J": 8, "sigma": sigma, "y": data},
+        num_simulations=10,
+        sample_kwargs={"num_warmup": 50, "num_samples": 25},
+        simulator=simulator,
+    )
+    sbc.run_simulations()
+    assert "prior_sbc" in sbc.simulations
+
+
+# --- Error handling tests with custom simulators ---
+def test_sbc_fail_no_observed_variable():
+    with pytest.raises(ValueError, match="no observed variables"):
+        simuk.SBC(
+            centered_eight_no_observed,
+            num_simulations=10,
+            sample_kwargs={"draws": 5, "tune": 5},
+        )
+
+
+def test_sbc_numpyro_fail_no_observed_variable():
+    # Note: factor variables are catalogued as 'observed_vars' in NumPyro
+    # therefore, we cannot raise an early exception with an informative message
+    with pytest.raises(ValueError):
+        sbc = simuk.SBC(
+            NUTS(eight_schools_cauchy_prior_no_observed),
+            data_dir={"J": 8, "sigma": sigma, "y": data},
+            num_simulations=10,
+            sample_kwargs={"num_warmup": 50, "num_samples": 25},
+        )
+        sbc.run_simulations()

--- a/simuk/tests/test_sbc.py
+++ b/simuk/tests/test_sbc.py
@@ -59,12 +59,14 @@ def eight_schools_cauchy_prior_no_observed(J, sigma, y=None):
 
 
 # Custom simulator functions
-def centered_eight_simulator(theta, **kwargs):
-    return {"y": np.random.normal(theta, sigma)}
+def centered_eight_simulator(theta, seed, **kwargs):
+    rng = np.random.default_rng(seed)
+    return {"y": rng.normal(theta, sigma)}
 
 
-def bmb_simulator(mu, sigma, **kwargs):
-    return {"y": np.random.normal(mu, sigma)}
+def bmb_simulator(mu, sigma, seed, **kwargs):
+    rng = np.random.default_rng(seed)
+    return {"y": rng.normal(mu, sigma)}
 
 
 # --- Tests with observed variables ---

--- a/simuk/tests/test_sbc.py
+++ b/simuk/tests/test_sbc.py
@@ -111,13 +111,26 @@ def test_sbc_numpyro_with_observed_data():
         (centered_eight, centered_eight_simulator),
         # Case 2: Only simulator function present
         (centered_eight_no_observed, centered_eight_simulator),
-        # Case 3: bambi model with custom simulator
-        (bmb_model, bmb_simulator),
     ],
 )
 def test_sbc_with_custom_simulator(model, simulator):
     sbc = simuk.SBC(
         model, num_simulations=10, sample_kwargs={"draws": 5, "tune": 5}, simulator=simulator
+    )
+    sbc.run_simulations()
+    assert "prior_sbc" in sbc.simulations
+
+
+@pytest.mark.skipif(
+    hasattr(bmb, "__version__") and tuple(map(int, bmb.__version__.split("."))) <= (0, 14),
+    reason="requires bambi version > 0.14",
+)
+def test_sbc_bambi_with_custom_simulator():
+    sbc = simuk.SBC(
+        bmb_model,
+        num_simulations=10,
+        sample_kwargs={"draws": 5, "tune": 5},
+        simulator=bmb_simulator,
     )
     sbc.run_simulations()
     assert "prior_sbc" in sbc.simulations

--- a/simuk/tests/test_sbc.py
+++ b/simuk/tests/test_sbc.py
@@ -6,6 +6,7 @@ import numpyro.distributions as dist
 import pandas as pd
 import pymc as pm
 import pytest
+from numba import njit
 from numpyro.infer import NUTS
 
 import simuk
@@ -62,6 +63,16 @@ def eight_schools_cauchy_prior_no_observed(J, sigma, y=None):
 def centered_eight_simulator(theta, seed, **kwargs):
     rng = np.random.default_rng(seed)
     return {"y": rng.normal(theta, sigma)}
+
+
+@njit
+def centered_eight_jitted_simulator(tau, mu, theta, seed):
+    # Some expensive computation
+    n = theta.shape[0]
+    y = np.zeros(n)
+    for i in range(n):
+        y[i] = theta[i]
+    return {"y": y}
 
 
 def bmb_simulator(mu, sigma, seed, **kwargs):


### PR DESCRIPTION
## Description

This PR adds an optional argument `simulator` to provide a more flexible user interface by allowing SBC to be used with (1) models with no observed variables and (2) custom simulators that do not match the probabilistic model. We discussed this possibility at #4 . It’s my first time using `numpyro` and contributing to some PyMC ecosystem library, so I’m happy to learn. 

I haven't updated the documentation, but test cases include new functionality, and I've written the following toy example. 


## Toy example for `simulator`
Let's say we are interested in modeling the annual dispersal of a species across a (1-dimensional) landscape. For example, we might want to estimate the average dispersal (`sigma`) from a dataset of `start` and `end` coordinates.
```python
from arviz_plots import plot_ecdf_pit
import pymc as pm
import numpy as np
import simuk
start_points = np.asarray([0., -5., 10., 15., 30.])
end_points = np.asarray([-10., 15., 20., 25., 20.])
displacement = end_points - start_points
# A very simple model could be
with pm.Model() as model:
    sigma = pm.HalfNormal("sigma", sigma=5)
    y_obs = pm.Normal("y", mu=0, sigma=sigma, observed=displacement)
```
The custom `simulator` function is useful when (a) having a model that does not have a built-in simulator (because it was a custom `Potential` call, for example) or (b) when we want to simulate data from a model that is not a probabilistic model.

Let's say we have a mechanistic model that describes the dispersal process. Starting and ending points were taken with a 1-year interval. Every day, an individual moves a distance drawn from an unknown distribution with finite variance. According to the central limit theorem, the total sum of the displacements (if independent) should follow a normal distribution with mean 0 and standard deviation sqrt(time) * sigma as time increases. We might wonder if 1 year is enough time for this approximation to be accurate, and we can test this using SMC for different dispersal distributions with a custom `simulator` function. 

```python
def simulator_uniform(seed, sigma):
    rng = np.random.default_rng(seed)
    time_in_days, n_obs = 365, 5
    a = -np.sqrt(3 * sigma**2 / time_in_days)
    b =  np.sqrt(3 * sigma**2 / time_in_days)
    steps = rng.uniform(a, b, size=(time_in_days, n_obs))
    return {'y': steps.sum(axis=0)}

sbc = simuk.SBC(model, num_simulations=100, simulator=simulator_uniform)
sbc.run_simulations()
plot_ecdf_pit(sbc.simulations)
```